### PR TITLE
Updated fields.py, made the string literal '^multiselectfield\.db.fields\.MultiSelectField' a raw string

### DIFF
--- a/multiselectfield/db/fields.py
+++ b/multiselectfield/db/fields.py
@@ -181,6 +181,6 @@ if VERSION < (1, 8):
 
 try:
     from south.modelsinspector import add_introspection_rules
-    add_introspection_rules([], ['^multiselectfield\.db.fields\.MultiSelectField'])
+    add_introspection_rules([], [r'^multiselectfield\.db.fields\.MultiSelectField'])
 except ImportError:
     pass


### PR DESCRIPTION
Updated fields.py, made the string literal '^multiselectfield\.db.fields\.MultiSelectField' a raw string.

Encountered a SyntaxWarning: invalid escape sequence on Heroku using Python 3.13 on line 184 of db/fields.py add_introspection_rules([], ['^multiselectfield\.db.fields\.MultiSelectField'])